### PR TITLE
Modify indentation in README.md to avoid GitHub displaying it incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ This will install two python packages and a binary.
 
   ```
   > yices_python_info
- Python Yices Bindings. Version 1.1.3
- Yices library loaded from /usr/local/lib/libyices.dylib
- Version: 2.6.2
- Architecture: x86_64-apple-darwin18.7.0 
- Build mode: debug
- Build date: 2020-04-27
- MCSat support: yes
- Thread safe: no
+  Python Yices Bindings. Version 1.1.3
+  Yices library loaded from /usr/local/lib/libyices.dylib
+  Version: 2.6.2
+  Architecture: x86_64-apple-darwin18.7.0 
+  Build mode: debug
+  Build date: 2020-04-27
+  MCSat support: yes
+  Thread safe: no
   ```
 
 ##  Examples


### PR DESCRIPTION
## Issue

On `master`, the indentation after `yices_python_info` causes GitHub to think that the code span has been terminated early. This means that the rest of the README is not displayed correctly.

## Resolution

This PR adjusts the indentation on README such that it is displayed correctly.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>